### PR TITLE
Remove unused DRUPAL_RECOMMENDED_PROJECT environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,5 @@ services:
     working_dir: /
     command: bash -c "/src/scripts/run-drupal-check.sh"
     tty: true
-    environment:
-      DRUPAL_RECOMMENDED_PROJECT: 11.2.x-dev
     volumes:
       - .:/src


### PR DESCRIPTION
## Summary
- Removes unused DRUPAL_RECOMMENDED_PROJECT environment variable from drupal-check service
- Cleans up docker-compose.yml configuration

## Test plan
- [x] Coding standards checks pass
- [ ] Verify drupal-check service still works without the environment variable

🤖 Generated with [Claude Code](https://claude.ai/code)