### PR TITLE
Reduce default factors to simplify initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # AI Content Marketing Audit
 
-AI-powered content marketing analysis evaluating seven critical
+AI-powered content marketing analysis evaluating five essential
 factors that drive engagement and business results.
 
 ## Features
 
-- **Seven Marketing Factors**: Usability, Knowledge Level, Actionability,
-  Accuracy, Business Value, Messaging, Brand Voice Fit
+- **Five Marketing Factors**: Usability, Knowledge Level, Actionability,
+  Accuracy, Funnel Stage
 - **Dual Analysis**: Quantitative scoring (-1.0 to +1.0) and qualitative
   classification
 - **Configurable Factors**: Add, edit, delete custom audit factors
@@ -61,9 +61,7 @@ drush en analyze_ai_content_marketing_audit
 2. **Knowledge Level**: Expertise demonstration
 3. **Actionability**: Clear next steps provided
 4. **Accuracy**: Factual correctness and currency
-5. **Business Value**: Support for business goals
-6. **Messaging**: Clarity and consistency
-7. **Brand Voice Fit**: Alignment with brand guidelines
+5. **Funnel Stage**: Marketing funnel targeting (Awareness/Consideration/Decision/Retention)
 
 ## Views Integration
 

--- a/analyze_ai_content_marketing_audit.install
+++ b/analyze_ai_content_marketing_audit.install
@@ -188,25 +188,7 @@ function analyze_ai_content_marketing_audit_install() {
       'type' => 'quantitative',
       'weight' => 3,
     ],
-    'business_value' => [
-      'label' => 'Business Value',
-      'description' => 'How well does the content support business goals and provide value to stakeholders?',
-      'type' => 'quantitative',
-      'weight' => 4,
-    ],
-    'messaging' => [
-      'label' => 'Messaging',
-      'description' => 'How clear, compelling, and consistent is the messaging?',
-      'type' => 'quantitative',
-      'weight' => 5,
-    ],
-    'brand_voice_fit' => [
-      'label' => 'Brand Voice Fit',
-      'description' => 'How well does the content align with the brand voice and tone guidelines?',
-      'type' => 'quantitative',
-      'weight' => 6,
-    ],
-      // Qualitative factors (categorical classification)
+    // Qualitative factors (categorical classification)
     'funnel_stage' => [
       'label' => 'Funnel Stage',
       'description' => 'Which stage of the marketing funnel does this content primarily target?',

--- a/docs/analyze_ai_content_marketing_audit_project_desc.html
+++ b/docs/analyze_ai_content_marketing_audit_project_desc.html
@@ -2,7 +2,7 @@
 
 <h2>Professional Content Marketing Analysis Powered by AI</h2>
 
-<blockquote>Transform your content strategy with comprehensive AI-powered marketing analysis based on proven content strategy principles, evaluating seven critical factors that drive engagement and business results.</blockquote>
+<blockquote>Transform your content strategy with comprehensive AI-powered marketing analysis based on proven content strategy principles, evaluating five essential factors that drive engagement and business results.</blockquote>
 
 <h3>You need Content Marketing Audit if</h3>
 <ul>
@@ -19,16 +19,14 @@
     <p>Multi-factor marketing analysis with both quantitative scoring (-1.0 to 1.0) and qualitative categorical classification, with customizable factor weighting and ordering.</p>
   </li>
   <li>
-    <strong>Seven Core Marketing Factors</strong>
+    <strong>Five Core Marketing Factors</strong>
     <p>Pre-configured analysis dimensions based on content strategy best practices:</p>
     <ul>
       <li><strong>Usability</strong> - Content ease of understanding and action</li>
       <li><strong>Knowledge Level</strong> - Expertise and authority demonstration</li>
       <li><strong>Actionability</strong> - Clear next steps and actionable insights</li>
       <li><strong>Accuracy</strong> - Factual correctness and currency</li>
-      <li><strong>Business Value</strong> - Support for business goals</li>
-      <li><strong>Messaging</strong> - Clarity and consistency</li>
-      <li><strong>Brand Voice Fit</strong> - Alignment with brand guidelines</li>
+      <li><strong>Funnel Stage</strong> - Marketing funnel targeting (Awareness/Consideration/Decision/Retention)</li>
     </ul>
   </li>
   <li>


### PR DESCRIPTION
Fixes #10

## Summary
Reduces default content marketing audit factors from 8 to 5 to simplify initial configuration and improve performance.

## Changes
- Removed 3 default factors: Business Value, Messaging, and Brand Voice Fit
- Preserved core content quality assessment with 4 quantitative + 1 qualitative factor
- Only affects new installations via install hook (existing installations unchanged)
- **Updated documentation** to reflect the reduced factor count

## Remaining Default Factors
**Quantitative (scored -1.0 to 1.0):**
- Usability - Content ease of understanding and action
- Knowledge Level - Expertise and authority demonstration  
- Actionability - Clear next steps and actionable insights
- Accuracy - Factual correctness and currency

**Qualitative (categorical):**
- Funnel Stage - Marketing funnel targeting (Awareness/Consideration/Decision/Retention)

## Documentation Updates
- Updated project description HTML (7 → 5 factors)
- Updated README.md with correct factor list
- Removed references to removed factors
- Added proper description of Funnel Stage factor

## Benefits  
✅ Simpler initial setup experience
✅ Faster analysis with fewer factors
✅ Users can still add custom factors via admin interface
✅ Maintains core content assessment capabilities
✅ Documentation accurately reflects new defaults

## Testing
- [x] Coding standards pass
- [x] No breaking changes to existing functionality
- [x] Install hook updated correctly
- [x] Documentation updated and consistent