### PR TITLE
Improve Views UX: select filter for factor, language filter, and standardize submit button

### DIFF
--- a/analyze_ai_content_marketing_audit.info.yml
+++ b/analyze_ai_content_marketing_audit.info.yml
@@ -5,7 +5,7 @@ package: Analyze
 core_version_requirement: ^10.2 || ^11
 dependencies:
   - drupal:views
-  - analyze:analyze
+  - analyze:analyze (>=1.1.0)
   - views_color_scales:views_color_scales
   - ai:ai
 configure: analyze_ai_content_marketing_audit.settings

--- a/analyze_ai_content_marketing_audit.install
+++ b/analyze_ai_content_marketing_audit.install
@@ -288,3 +288,89 @@ function analyze_ai_content_marketing_audit_update_8001() {
 
   return t('No content marketing audit analyzer settings found to update.');
 }
+
+/**
+ * Update view: factor_id filter, language filter, and submit button.
+ */
+function analyze_ai_content_marketing_audit_update_8002() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('views.view.ai_content_marketing_audit_results');
+
+  if ($config->isNew()) {
+    return t('View not found.');
+  }
+
+  $filters = $config->get('display.default.display_options.filters') ?? [];
+
+  // Update factor_id filter to use analyze_select.
+  foreach ($filters as $filter_id => $filter) {
+    if (($filter['field'] ?? '') === 'factor_id' && ($filter['plugin_id'] ?? '') === 'string') {
+      $filters[$filter_id]['plugin_id'] = 'analyze_select';
+      $filters[$filter_id]['operator'] = 'in';
+      $filters[$filter_id]['value'] = [];
+    }
+  }
+
+  // Remove old langcode filter if present.
+  unset($filters['langcode']);
+
+  // Add language filter using node relationship.
+  $langcode_filter = [
+    'id' => 'langcode',
+    'table' => 'node_field_data',
+    'field' => 'langcode',
+    'relationship' => 'entity_id',
+    'group_type' => 'group',
+    'admin_label' => '',
+    'entity_type' => 'node',
+    'entity_field' => 'langcode',
+    'plugin_id' => 'language',
+    'operator' => 'in',
+    'value' => [
+      '***LANGUAGE_site_default***' => '***LANGUAGE_site_default***',
+    ],
+    'group' => 1,
+    'exposed' => TRUE,
+    'expose' => [
+      'operator_id' => 'langcode_op',
+      'label' => 'Translation language',
+      'description' => '',
+      'use_operator' => FALSE,
+      'operator' => 'langcode_op',
+      'operator_limit_selection' => FALSE,
+      'operator_list' => [],
+      'identifier' => 'langcode',
+      'required' => FALSE,
+      'remember' => FALSE,
+      'multiple' => FALSE,
+      'remember_roles' => [
+        'authenticated' => 'authenticated',
+      ],
+      'reduce' => FALSE,
+    ],
+    'is_grouped' => FALSE,
+    'group_info' => [
+      'label' => '',
+      'description' => '',
+      'identifier' => '',
+      'optional' => TRUE,
+      'widget' => 'select',
+      'multiple' => FALSE,
+      'remember' => FALSE,
+      'default_group' => 'All',
+      'default_group_multiple' => [],
+      'group_items' => [],
+    ],
+  ];
+
+  // Add langcode filter at the beginning.
+  $filters = ['langcode' => $langcode_filter] + $filters;
+  $config->set('display.default.display_options.filters', $filters);
+
+  // Standardize submit button.
+  $config->set('display.default.display_options.exposed_form.options.submit_button', 'Apply filters');
+
+  $config->save();
+
+  return t('Updated view filters and submit button.');
+}

--- a/analyze_ai_content_marketing_audit.views.inc
+++ b/analyze_ai_content_marketing_audit.views.inc
@@ -71,10 +71,10 @@ function analyze_ai_content_marketing_audit_views_data() {
   $data['analyze_ai_content_marketing_audit_results']['langcode'] = [
     'title' => t('Language'),
     'help' => t('The language of the analyzed content.'),
-    'field' => ['id' => 'standard'],
-    'filter' => ['id' => 'string'],
+    'field' => ['id' => 'language'],
+    'filter' => ['id' => 'language'],
     'sort' => ['id' => 'standard'],
-    'argument' => ['id' => 'string'],
+    'argument' => ['id' => 'language'],
   ];
 
   // Factor ID field.
@@ -82,7 +82,10 @@ function analyze_ai_content_marketing_audit_views_data() {
     'title' => t('Factor Type'),
     'help' => t('The marketing factor identifier (e.g., "usability", "accuracy").'),
     'field' => ['id' => 'standard'],
-    'filter' => ['id' => 'string'],
+    'filter' => [
+      'id' => 'analyze_select',
+      'options_callback' => 'analyze_ai_content_marketing_audit.storage:getFactorSelectOptions',
+    ],
     'sort' => ['id' => 'standard'],
     'argument' => ['id' => 'string'],
     'relationship' => [

--- a/config/install/views.view.ai_content_marketing_audit_results.yml
+++ b/config/install/views.view.ai_content_marketing_audit_results.yml
@@ -387,7 +387,7 @@ display:
       exposed_form:
         type: basic
         options:
-          submit_button: Search
+          submit_button: 'Apply filters'
           reset_button: false
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
@@ -418,6 +418,48 @@ display:
           granularity: second
       arguments: {  }
       filters:
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: entity_id
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_site_default***': '***LANGUAGE_site_default***'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: 'Translation language'
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         factor_id:
           id: factor_id
           table: analyze_ai_content_marketing_audit_results
@@ -425,9 +467,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: string
-          operator: '='
-          value: ''
+          plugin_id: analyze_select
+          operator: in
+          value: {  }
           group: 1
           exposed: true
           expose:

--- a/src/Service/ContentMarketingAuditStorageService.php
+++ b/src/Service/ContentMarketingAuditStorageService.php
@@ -185,6 +185,21 @@ final class ContentMarketingAuditStorageService {
   }
 
   /**
+   * Gets factor options for Views select filter.
+   *
+   * @return array<string, string>
+   *   Array of factor labels keyed by factor ID.
+   */
+  public function getFactorSelectOptions(): array {
+    $factors = $this->getFactors();
+    $options = [];
+    foreach ($factors as $factor_id => $factor_data) {
+      $options[$factor_id] = $factor_data['label'] ?? $factor_id;
+    }
+    return $options;
+  }
+
+  /**
    * Gets the options for a qualitative factor.
    *
    * @param string $factor_id


### PR DESCRIPTION
## Summary
- Convert factor_id filter from text input to select dropdown using `analyze_select` plugin
- Add exposed language filter using node relationship, defaulting to site's default language
- Change submit button text to "Apply filters" for consistency across analyze modules
- Add `getFactorSelectOptions()` method for filter options
- Consolidate update hooks into single `hook_update_8002`

## Test plan
- [ ] Run `drush updb` to apply update hook
- [ ] Run `drush cr` to rebuild caches (required for Views to recognize the new filter plugin)
- [ ] Verify factor filter is now a dropdown
- [ ] Verify language filter appears and defaults to site's default language
- [ ] Verify submit button shows "Apply filters"

Closes #12